### PR TITLE
reboot: not correctly checking host reachability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A role for rebooting hosts.
 |---------------------------|-----------------------------------------------------------|--------------------------------------------|
 | `reboot_message`          | Reboot message for the logs                               | 'Reboot by Ansible'                        |
 | `reboot_wait`             | Wait for hosts to come back online?                       | 'yes'                                      |
+| `reboot_connect_timeout`  | Connection timeout before retrying.                       | 20                                         |
 | `reboot_wait_host`        | Host to check                                             | `ansible_ssh_host` or `inventory_hostname` |
 | `reboot_wait_port`        | Port to check                                             | `ansible_ssh_port` or 22                   |
 | `reboot_wait_regex`       | String to match in the socket connection. (ex. `OpenSSH`) | /                                          |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ reboot_message: 'Reboot by Ansible'
 # Wait for host?
 reboot_wait: 'yes'
 
+# Maximum number of seconds to wait for a connection to happen before closing and retrying.
+reboot_connect_timeout: 20
+
 # Time to wait before polling the host
 reboot_wait_delay: 10
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,31 +7,12 @@
   poll: 0
   ignore_errors: yes
 
-  # Make sure ansible_ssh_host has the correct value inside the local_action module
-- name: Set default reboot_wait_host
-  become: no
-  set_fact:
-    reboot_wait_host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
-  when: (reboot_wait|bool) and reboot_wait_host is undefined
-
-  # Make sure ansible_ssh_port has the correct value inside the local_action module
-- name: Set default reboot_wait_port
-  become: no
-  set_fact:
-    reboot_wait_port: "{{ ansible_ssh_port | default(22) }}"
-  when: (reboot_wait|bool) and reboot_wait_port is undefined
-
 - name: Wait for host
-  become: no
-  wait_for:
-    host: "{{ reboot_wait_host }}"
-    port: "{{ reboot_wait_port }}"
-    state: started
+  wait_for_connection:
+    connect_timeout: "{{ reboot_connect_timeout }}"
+    sleep: "{{ reboot_wait_ctimeout }}"
     delay: "{{ reboot_wait_delay }}"
     timeout: "{{ reboot_wait_timeout }}"
-    search_regex: "{{ reboot_wait_regex | default(omit) }}"
-    connect_timeout: "{{ reboot_wait_ctimeout }}"
-  delegate_to: localhost
   when: reboot_wait|bool
 
 - name: Interval before next task


### PR DESCRIPTION
Come across the issue where after that the reboot has completed host was
not yet reachable. This is because the host was still booting hence
refusing SSH connection even if SSH service was up and running. wait_for
is the old way to check host reachability and it produced unreliable
results, because the system needs to be booted and we need to make sure
we can execute command over it before continuing the next task.

wait_for_connection does that pretty automatically, it wait for the host
to be reachable and ensure we can run command on it.

Signed-off-by: Lionel H <lionel.hubaut@tessares.net>